### PR TITLE
Added post processing build script.

### DIFF
--- a/sources/build.sh
+++ b/sources/build.sh
@@ -1,0 +1,5 @@
+# Remove default x height rounding
+ttfautohint -x 0 ../fonts/Voces-Regular.ttf ../fonts/Voces-Regular1.ttf 
+rm ../fonts/Voces-Regular.ttf 
+mv ../fonts/Voces-Regular1.ttf ../fonts/Voces-Regular.ttf 
+echo 'Done removing autohint x-height rounding'


### PR DESCRIPTION
Run this after generating the font from Glyphsapp. Script will remove
the default ttf x-height rounding